### PR TITLE
Change restricted bit function (~2x) speedup

### DIFF
--- a/apps/restriction.py
+++ b/apps/restriction.py
@@ -56,15 +56,15 @@ class RestrictionInventory:
         # Try to get cached inventory from shared memcache instance
         if cached_inventory:
             self._inv = pickle.loads(cached_inventory)
-            self._restricted_seedIDs = [
+            self._restricted_seedIDs = set([
                 seedId
                 for seedId in self._inv
                 if any(e.restriction != Restriction.OPEN for e in self._inv[seedId])
-            ]
-            self._known_seedIDs = [
+            ])
+            self._known_seedIDs = set([
                 seedId
                 for seedId in self._inv
-            ]
+            ])
             logging.info(f"Loaded inventory from cache...")
             return
         else:

--- a/apps/wfcatalog_client.py
+++ b/apps/wfcatalog_client.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from fnmatch import fnmatch
 from flask import current_app
 from .redis_client import RedisClient

--- a/apps/wfcatalog_client.py
+++ b/apps/wfcatalog_client.py
@@ -112,10 +112,8 @@ def _apply_restricted_bit(data: list) -> list:
       if sid not in RESTRICTED_INVENTORY._known_seedIDs:
         continue
 
-      status = "OPEN"
-
       if sid in RESTRICTED_INVENTORY._restricted_seedIDs:
-        status = _get_restricted_status(segment)
+        segment["restr"] = _get_restricted_status(segment)
 
       results.append([
         segment["net"],
@@ -127,7 +125,7 @@ def _apply_restricted_bit(data: list) -> list:
         segment["ts"],
         segment["te"],
         segment["created"],
-        status,
+        segment["restr"],
         segment["count"]
     ])
 

--- a/apps/wfcatalog_client.py
+++ b/apps/wfcatalog_client.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from fnmatch import fnmatch
 from flask import current_app
 from .redis_client import RedisClient
@@ -45,7 +46,6 @@ def mongo_request(paramslist):
 
     # List of queries executed agains the DB, let's keep it for logging
     qries = []
-
     for params in paramslist:
         params = _expand_wildcards(params)
         qry = {}
@@ -83,17 +83,12 @@ def mongo_request(paramslist):
         cursor = db.availability.find(qry, projection=PROJ)
 
         # Eager query execution instead of a cursor
-        data = list(cursor)
-        data = _apply_restricted_bit(data)
-        result += [
-            [data[idx][key] for key in data[idx].keys()] for idx, _ in enumerate(data)
-        ]
+        result += _apply_restricted_bit(cursor)
 
     # Result needs to be sorted, this seems to be required by the fusion step
     result.sort(key=lambda x: (x[0], x[1], x[2], x[3], x[4]))
 
     return qries, result
-
 
 def _apply_restricted_bit(data: list) -> list:
     """Removes entries which do not appear in the station inventory and applies
@@ -108,39 +103,35 @@ def _apply_restricted_bit(data: list) -> list:
         restricted information applied from cache.
     """
 
-    # Filter out SEED Identifiers not existing in station metadata.
-    data = [
-        r
-        for r in data
-        if f"{r['net']}.{r['sta']}.{r['loc']}.{r['cha']}"
-        in RESTRICTED_INVENTORY._known_seedIDs
-    ]
+    results = []
 
-    # Take the intersection between DB entries and restricted cached inventory.
-    intersection = set(
-        [f"{r['net']}.{r['sta']}.{r['loc']}.{r['cha']}" for r in data]
-    ) & set(RESTRICTED_INVENTORY._restricted_seedIDs)
+    for segment in data:
 
-    # Apply the restricted bit information from the cached inventory side.
-    if len(intersection) > 0:
-        logging.info(f"Applying restricted bit for {intersection=}")
-        for seedId in intersection:
-            net, sta, loc, cha = seedId.split(".")
-            indexes = [
-                i
-                for i, e in enumerate(data)
-                if (
-                    e["net"] == net
-                    and e["sta"] == sta
-                    and e["loc"] == loc
-                    and e["cha"] == cha
-                )
-            ]
-            for index in indexes:
-                data[index]["restr"] = _get_restricted_status(data[index])
+      sid = ".".join([segment["net"], segment["sta"], segment["loc"], segment["cha"]])
 
-    return data
+      if sid not in RESTRICTED_INVENTORY._known_seedIDs:
+        continue
 
+      status = "OPEN"
+
+      if sid in RESTRICTED_INVENTORY._restricted_seedIDs:
+        status = _get_restricted_status(segment)
+
+      results.append([
+        segment["net"],
+        segment["sta"],
+        segment["loc"],
+        segment["cha"],
+        segment["qlt"],
+        segment["srate"],
+        segment["ts"],
+        segment["te"],
+        segment["created"],
+        status,
+        segment["count"]
+    ])
+
+    return results
 
 def _expand_wildcards(params):
     """Expand generic query parameters to actual ones based on cached inventory.


### PR DESCRIPTION
Don't merge this but maybe cherry pick these improvements to `master`. I have changed the inventory lookups to a `set` that is better than using `list`. Simplified logic of `_apply_restricted_bit` and made to work directly with a cursor object and return the [[], []] structure immediately instead of doing another list comprehension. It should loop over each segment only once now.

However, check if I didn't remove any important logic because I missed it!