### PR TITLE
Release v1.1.1 — avail-rebuild CLI + deployable pre-built images

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ The cacher runs a built-in scheduler — no host cron needed:
 
 - **03:00 UTC** — refresh the restriction inventory from FDSNWS-Station into Redis.
 - **06:00 UTC** — update the `availability` view from the last 4 days of WFCatalog data.
-- **On startup** — both run once, so a restart leaves data fresh.
+- **On startup** — both run once, so a restart leaves recent data fresh.
+
+This covers only the recent window. To repair an older date (e.g. after a backfill), see [Back-processing](#back-processing-historical--scoped-rebuild).
 
 ## Tuning (optional)
 
@@ -146,16 +148,33 @@ The compound index `{ net: 1, sta: 1, loc: 1, cha: 1, ts: 1, te: 1 }` is created
 
 After the initial build, the cacher keeps the view current automatically (see [What runs daily](#what-runs-daily)) — **no host cron is needed** (earlier versions required one; it has been replaced by the built-in scheduler).
 
-### Back-processing
+### Back-processing (historical / scoped rebuild)
 
-The daily scheduler only refreshes a rolling recent window. To reprocess a specific historical range or a subset of streams — e.g. after a data correction or a backfill — run `views/main.js` manually with parameters (`networks`/`stations` accept regex):
+The daily scheduler only refreshes a **rolling recent window** (the last 4 days). It therefore *cannot* repair a historical gap: if WFCatalog is (re)populated for an old date — e.g. after a backfill, or a data correction surfaced by an [EIDA consistency report](https://github.com/EIDA) — restarting the cacher does **not** rebuild that date, so `/query` and `/extent` keep reporting "no data" even though dataselect / the SDS archive serve it. You must reprocess that range explicitly.
+
+> **Prerequisite:** back-processing only re-derives the view *from* WFCatalog (`daily_streams`/`c_segments`). It does **not** scan the SDS archive. If WFCatalog itself is missing the range, refresh WFCatalog for those dates **first**, otherwise the rebuild completes cleanly but writes nothing.
+
+**Preferred — the `avail-rebuild` CLI** (runs inside the cacher, so it uses the container's own MongoDB credentials; supports full NSLC):
 
 ```bash
-# A specific month
-mongosh -u USER -p PASSWORD --authenticationDatabase wfrepo \
-  --eval "start='2023-01-01'; end='2023-01-31'" views/main.js
+# A network/station over a range (all of 2008 -> end is the day boundary, 2009-01-01)
+docker exec fdsnws-availability-cacher \
+  avail-rebuild --net IV --sta ABC --start 2008-01-01 --end 2009-01-01
 
-# One network/station over a range
+# Channel-precise (e.g. just HHZ; --loc=-- means the empty location.
+# Use the attached '=' form: a bare '--' is read by the shell/argparse as end-of-options.)
+docker exec fdsnws-availability-cacher \
+  avail-rebuild --net IV --sta ABC --loc=-- --cha HHZ --start 2008-01-01 --end 2009-01-01
+
+# Whole range, all streams
+docker exec fdsnws-availability-cacher avail-rebuild --start 2023-01-01 --end 2023-02-01
+```
+
+`--net/--sta/--loc/--cha` are comma-separated exact-match lists; omit any to leave it unconstrained. The rebuild is idempotent (`$merge whenMatched:"replace"`) — safe to re-run. After it finishes, flush Redis or wait out `CACHE_RESP_PERIOD` before re-checking, in case an empty response for that query is still cached. (If the console script isn't on `PATH` for some reason, `docker exec fdsnws-availability-cacher python -m apps.cli …` is equivalent.)
+
+**Fallback — `views/main.js` via `mongosh`** (host-side; net+sta+date only, no loc/cha; needs a repo checkout and DB creds on the host):
+
+```bash
 mongosh -u USER -p PASSWORD --authenticationDatabase wfrepo \
   --eval "networks='NL'; stations='HGN'; start='2022-12-01'; end='2023-01-31'" views/main.js
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Flask implementation of the [FDSN Availability web service 1.0](http://www.fds
 
 It runs as three Docker containers: the **API** (Flask + gunicorn, port 9001), a **Redis** cache, and a **cacher** that keeps the restriction inventory and the `availability` view up to date on a built-in daily schedule.
 
-> **Upgrading from v1.0.x?** Follow [`BETA.md`](BETA.md) for the exact upgrade steps (config.py changes, the in-app scheduler replacing host cron).
+> **Upgrading from v1.0.x?** See [Upgrading from v1.0.x](#upgrading-from-v10x) for the exact `config.py` changes — it's a quick, self-contained checklist.
 
 ## Deployment
 
@@ -54,6 +54,50 @@ curl "127.0.0.1:9001/extent?net=NA&start=2023-02-01"
 ```
 
 For a node that already has a populated WFCatalog, that's the whole install. A brand-new database also needs the one-time [database setup](#first-time-database-setup). Requires MongoDB ≥ 4.2.
+
+## Upgrading from v1.0.x
+
+Upgrading reuses the same containers and the same `config.py`. The only manual step is making sure `config.py` has the keys the new version expects, then rebuilding.
+
+> **What changed for operators:** `config.py` is now the **only** place to set MongoDB, FDSNWS-Station and Sentry settings. `docker-compose.yml` no longer passes them to the container, so your edits in `config.py` actually take effect.
+
+1. **Get the new code.** Your `config.py` is gitignored, so this won't touch it:
+
+   ```bash
+   git fetch && git checkout v1.1.0
+   ```
+
+2. **Add any missing `config.py` keys.** `MONGODB_*`, `CACHE_*` and `FDSNWS_STATION_URL` are unchanged — keep your values. What to add depends on the version you're coming from (add the lines inside the `try:` block, next to the other `os.environ.get(...)` lines):
+
+   - **From v1.0.5 or v1.0.4** — add one line:
+
+     ```python
+     SENTRY_ENVIRONMENT = "yournode_production"
+     ```
+
+   - **From v1.0.3 or earlier** (predates Sentry) — add all three:
+
+     ```python
+     SENTRY_DSN = os.environ.get("SENTRY_DSN", "")          # your Sentry DSN, or "" to disable
+     SENTRY_TRACES_SAMPLE_RATE = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "1.0"))
+     SENTRY_ENVIRONMENT = "yournode_production"
+     ```
+
+   **`SENTRY_ENVIRONMENT` is required and must be unique per node** (e.g. `noa_production`, `resif_production`) so your events are distinguishable in Sentry. Not sure what's missing? Diff against the sample — see [Troubleshooting](#troubleshooting).
+
+3. **Rebuild and restart:**
+
+   ```bash
+   docker-compose up -d --build          # or: docker-compose pull && docker-compose up -d
+   ```
+
+4. **Remove the old host cron**, if you had one triggering `views/main.js` — it's now redundant, replaced by the [built-in scheduler](#what-runs-daily):
+
+   ```bash
+   crontab -l | grep -v "ws-availability.*views.*main.js" | crontab -
+   ```
+
+Then re-run the `curl` checks above; `/version` should report `1.1.0`.
 
 ## Endpoints
 

--- a/apps/cli.py
+++ b/apps/cli.py
@@ -1,0 +1,163 @@
+"""
+avail-rebuild — on-demand rebuild of the `availability` materialized view for a
+specific date range and (optionally) a specific NSLC subset.
+
+Why this exists
+---------------
+The cacher's daily scheduler only refreshes a rolling recent window
+(`run_updates(days_back=4)` in apps/scheduler.py). It cannot repair *historical*
+gaps: if WFCatalog is (re)populated for an old date — e.g. after a backfill or a
+data correction surfaced by an EIDA consistency report — the availability view
+for that date is never rebuilt, so `/availability` keeps reporting "no data"
+even though dataselect / the SDS archive serve it.
+
+The underlying engine (`AvailabilityUpdater.run_updates`) already accepts an
+arbitrary start/end and is idempotent (`$merge whenMatched:"replace"`). Until
+now the only ways to drive it for an old range were the host-side
+`mongosh ... views/main.js` invocation (needs a repo checkout + DB creds on the
+host, and is net+sta+date only) or editing the scheduler. This CLI exposes the
+engine as a stable, versioned, in-container interface so an orchestrator (dmtri)
+can trigger a scoped rebuild without reaching into MongoDB:
+
+    docker exec fdsnws-availability-cacher \
+        avail-rebuild --net IV --sta ABC --start 2008-01-01 --end 2009-01-01
+
+Running inside the cacher means MongoDB credentials come from the container's
+own config.py/settings — the caller never handles DB secrets. Unlike main.js it
+also accepts full NSLC (--loc/--cha) for channel-precise rebuilds.
+
+Prerequisite
+------------
+WFCatalog (`daily_streams`/`c_segments`) must already contain the range. This
+tool only re-derives the view *from* WFCatalog; it does not scan the SDS
+archive. Run the WFCatalog refresh for the range first — otherwise the rebuild
+completes cleanly but writes nothing.
+"""
+import argparse
+import logging
+import sys
+from datetime import datetime
+from typing import Optional
+
+from apps.settings import settings
+from apps.updater import AvailabilityUpdater
+from apps.wfcatalog_client import get_db_client
+
+logging.basicConfig(
+    handlers=[logging.StreamHandler()],
+    level=logging.INFO,
+    format="[%(asctime)s] [AVAIL-REBUILD] [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S +0000",
+)
+logger = logging.getLogger(__name__)
+
+
+def _anchor_regex(csv: Optional[str]) -> str:
+    """Turn "IV,GE" into the anchored regex ``^(IV|GE)$`` (exact match per code).
+
+    None/empty -> ``^.*$`` (match all), mirroring ``run_updates``' default and
+    main.js's ``^${networks}$`` convention.
+    """
+    if not csv:
+        return "^.*$"
+    codes = [c.strip() for c in csv.split(",") if c.strip()]
+    if not codes:
+        return "^.*$"
+    return "^(" + "|".join(codes) + ")$"
+
+
+def _code_list(csv: Optional[str]) -> Optional[list[str]]:
+    """Turn "00,--" into ``["00", ""]``; ``--`` denotes the empty location.
+
+    None -> None (dimension left unconstrained in the aggregation).
+    """
+    if csv is None:
+        return None
+    return ["" if c.strip() == "--" else c.strip() for c in csv.split(",")]
+
+
+def _parse_day(value: str) -> datetime:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"invalid date '{value}', expected YYYY-MM-DD"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="avail-rebuild",
+        description=(
+            "Rebuild the availability materialized view for a date range (and "
+            "optional NSLC subset) from WFCatalog. Idempotent — safe to re-run."
+        ),
+    )
+    p.add_argument("--net", help="Comma-separated network codes (exact). Default: all.")
+    p.add_argument("--sta", help="Comma-separated station codes (exact). Default: all.")
+    p.add_argument(
+        "--loc",
+        help="Comma-separated location codes (exact). For the empty location pass "
+             "--loc=-- (attached form) or --loc '' . Default: all.",
+    )
+    p.add_argument("--cha", help="Comma-separated channel codes (exact). Default: all.")
+    p.add_argument(
+        "--start", required=True, type=_parse_day,
+        help="Range start, YYYY-MM-DD (inclusive).",
+    )
+    p.add_argument(
+        "--end", required=True, type=_parse_day,
+        help="Range end, YYYY-MM-DD. Day boundary: matches segments with te <= end "
+             "(e.g. for all of 2008 use --end 2009-01-01).",
+    )
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.end < args.start:
+        logger.error(
+            "END (%s) is before START (%s) — nothing to do.",
+            args.end.date(), args.start.date(),
+        )
+        return 2
+
+    # Sentry is optional; never let its wiring (or a missing config.py) block a
+    # rebuild.
+    try:
+        from apps.sentry import init_sentry
+        init_sentry()
+    except Exception as e:  # pragma: no cover - defensive, env-dependent
+        logger.warning("Sentry init skipped: %s", e)
+
+    networks = _anchor_regex(args.net)
+    stations = _anchor_regex(args.sta)
+    locations = _code_list(args.loc)
+    channels = _code_list(args.cha)
+
+    db = get_db_client().get_database(settings.mongodb_name)
+    updater = AvailabilityUpdater(db)
+
+    logger.info(
+        "Rebuild start: net=%s sta=%s loc=%s cha=%s range=%s..%s db=%s",
+        networks, stations, locations, channels,
+        args.start.date(), args.end.date(), settings.mongodb_name,
+    )
+    updater.run_updates(
+        networks=networks,
+        stations=stations,
+        start_date=args.start,
+        end_date=args.end,
+        locations=locations,
+        channels=channels,
+    )
+    logger.info(
+        "Rebuild complete. If a previous query was cached, flush Redis or wait "
+        "out CACHE_RESP_PERIOD before re-checking /availability."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/globals.py
+++ b/apps/globals.py
@@ -38,7 +38,7 @@ ORDERBY = (
 # error message constants
 DOCUMENTATION_URI = "http://www.fdsn.org/webservices/fdsnws-availability-1.0.pdf"
 SERVICE = "fdsnws-availability"
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 
 class Error:

--- a/apps/updater.py
+++ b/apps/updater.py
@@ -8,6 +8,35 @@ from pymongo.database import Database
 logger = logging.getLogger(__name__)
 
 
+def _nslc_match(
+    networks: str,
+    stations: str,
+    start_date: datetime,
+    end_date: datetime,
+    avail: dict,
+    locations: Optional[list[str]] = None,
+    channels: Optional[list[str]] = None,
+) -> dict:
+    """Build the stage-0 ``$match`` shared by the daily and continuous pipelines.
+
+    net/sta stay ``$regex`` (the scheduler/legacy default is ``^.*$``). loc/cha
+    are optional exact-match ``$in`` lists, added only when provided — so with
+    both None the match is byte-identical to the original net+sta+date filter.
+    """
+    match: dict = {
+        "net": {"$regex": networks},
+        "sta": {"$regex": stations},
+        "ts": {"$gte": start_date},
+        "te": {"$lte": end_date},
+        "avail": avail,
+    }
+    if locations is not None:
+        match["loc"] = {"$in": locations}
+    if channels is not None:
+        match["cha"] = {"$in": channels}
+    return match
+
+
 class AvailabilityUpdater:
     def __init__(self, db: Database):
         self.db = db
@@ -18,19 +47,23 @@ class AvailabilityUpdater:
         stations: str,
         start_date: datetime,
         end_date: datetime,
+        locations: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
     ):
         """
-        Equivalent to `updateAvailabilityDaily` in views/main.js
+        Equivalent to `updateAvailabilityDaily` in views/main.js.
+
+        ``locations``/``channels`` are optional exact-match filters (lists of
+        codes). When None the dimension is unconstrained — preserving the
+        original net+sta+date behavior the daily scheduler relies on. An empty
+        location is the empty string "" (callers normalize "--" -> "").
         """
         pipeline = [
             {
-                "$match": {
-                    "net": {"$regex": networks},
-                    "sta": {"$regex": stations},
-                    "ts": {"$gte": start_date},
-                    "te": {"$lte": end_date},
-                    "avail": {"$gte": 100},
-                }
+                "$match": _nslc_match(
+                    networks, stations, start_date, end_date,
+                    avail={"$gte": 100}, locations=locations, channels=channels,
+                )
             },
             {
                 "$group": {
@@ -60,19 +93,23 @@ class AvailabilityUpdater:
         stations: str,
         start_date: datetime,
         end_date: datetime,
+        locations: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
     ):
         """
-        Equivalent to `updateAvailabilityContinuous` in views/main.js
+        Equivalent to `updateAvailabilityContinuous` in views/main.js.
+
+        The optional ``locations``/``channels`` filters are applied at the
+        stage-0 ``$match`` against ``daily_streams`` (where net/sta/loc/cha
+        live), restricting which streams' continuous segments get rebuilt.
+        See ``update_availability_daily`` for the filter semantics.
         """
         pipeline = [
             {
-                "$match": {
-                    "net": {"$regex": networks},
-                    "sta": {"$regex": stations},
-                    "ts": {"$gte": start_date},
-                    "te": {"$lte": end_date},
-                    "avail": {"$lt": 100},
-                }
+                "$match": _nslc_match(
+                    networks, stations, start_date, end_date,
+                    avail={"$lt": 100}, locations=locations, channels=channels,
+                )
             },
             {
                 "$lookup": {
@@ -112,9 +149,15 @@ class AvailabilityUpdater:
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         days_back: Optional[int] = None,
+        locations: Optional[list[str]] = None,
+        channels: Optional[list[str]] = None,
     ):
         """
         Main runner function replicating the logic at the bottom of main.js.
+
+        ``locations``/``channels`` are optional exact-match NSLC filters passed
+        through to both pipelines; None (the default, used by the scheduler)
+        leaves that dimension unconstrained.
         """
         now = datetime.utcnow()
         if days_back is not None:
@@ -135,8 +178,12 @@ class AvailabilityUpdater:
             f"Processing WFCatalog entries using networks: '{networks}', stations: '{stations}', start: '{start_date.isoformat()}', end: '{end_date.isoformat()}' started!"
         )
 
-        self.update_availability_daily(networks, stations, start_date, end_date)
-        self.update_availability_continuous(networks, stations, start_date, end_date)
+        self.update_availability_daily(
+            networks, stations, start_date, end_date, locations, channels
+        )
+        self.update_availability_continuous(
+            networks, stations, start_date, end_date, locations, channels
+        )
 
         logger.info(
             f"Processing WFCatalog entries using networks: '{networks}', stations: '{stations}', start: '{start_date.isoformat()}', end: '{end_date.isoformat()}' completed!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       nproc: 65535
     security_opt:
       - seccomp:unconfined
+    volumes:
+      # Operator config lives on the host. Mounting it (rather than relying on
+      # it being baked into the image) is what makes the pre-built GHCR images
+      # usable: pull, set config.py, run — no rebuild. Read-only by design.
+      - ./config.py:/appli/config.py:ro
   api:
     build:
       context: ./
@@ -59,6 +64,8 @@ services:
         hard: 65535
     security_opt:
       - seccomp:unconfined
+    volumes:
+      - ./config.py:/appli/config.py:ro
     mem_limit: 2g
     memswap_limit: 2g
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ws-availability"
-version = "1.1.0"
+version = "1.1.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -20,6 +20,12 @@ dependencies = [
     "sentry-sdk[flask]>=2.0.0",
     "apscheduler>=3.11.2",
 ]
+
+[project.scripts]
+# On-demand historical/scoped rebuild of the availability view (apps/cli.py).
+# Invoked inside the cacher, e.g.:
+#   docker exec fdsnws-availability-cacher avail-rebuild --net IV --start 2008-01-01 --end 2009-01-01
+avail-rebuild = "apps.cli:main"
 
 [dependency-groups]
 dev = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,71 @@
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from apps.cli import _anchor_regex, _code_list, build_parser, main
+
+
+class TestCliHelpers(unittest.TestCase):
+    def test_anchor_regex(self):
+        self.assertEqual(_anchor_regex(None), "^.*$")
+        self.assertEqual(_anchor_regex(""), "^.*$")
+        self.assertEqual(_anchor_regex("IV"), "^(IV)$")
+        self.assertEqual(_anchor_regex("IV,GE"), "^(IV|GE)$")
+        self.assertEqual(_anchor_regex(" IV , GE "), "^(IV|GE)$")
+
+    def test_code_list(self):
+        self.assertIsNone(_code_list(None))
+        self.assertEqual(_code_list("00,10"), ["00", "10"])
+        self.assertEqual(_code_list("--"), [""])          # empty location sentinel
+        self.assertEqual(_code_list("00,--"), ["00", ""])
+
+    def test_parser_requires_dates(self):
+        with self.assertRaises(SystemExit):
+            build_parser().parse_args(["--net", "IV"])  # no --start/--end
+
+    def test_parser_rejects_bad_date(self):
+        with self.assertRaises(SystemExit):
+            build_parser().parse_args(["--start", "2008/01/01", "--end", "2009-01-01"])
+
+
+class TestCliMain(unittest.TestCase):
+    @patch("apps.cli.get_db_client")
+    @patch("apps.cli.AvailabilityUpdater")
+    def test_main_maps_args_to_run_updates(self, MockUpdater, _mock_db):
+        inst = MockUpdater.return_value
+        rc = main([
+            "--net", "IV", "--sta", "ABC", "--loc=--", "--cha", "HHZ",
+            "--start", "2008-01-01", "--end", "2009-01-01",
+        ])
+        self.assertEqual(rc, 0)
+        inst.run_updates.assert_called_once()
+        kwargs = inst.run_updates.call_args.kwargs
+        self.assertEqual(kwargs["networks"], "^(IV)$")
+        self.assertEqual(kwargs["stations"], "^(ABC)$")
+        self.assertEqual(kwargs["locations"], [""])
+        self.assertEqual(kwargs["channels"], ["HHZ"])
+        self.assertEqual(kwargs["start_date"], datetime(2008, 1, 1))
+        self.assertEqual(kwargs["end_date"], datetime(2009, 1, 1))
+
+    @patch("apps.cli.get_db_client")
+    @patch("apps.cli.AvailabilityUpdater")
+    def test_main_defaults_to_all_streams(self, MockUpdater, _mock_db):
+        inst = MockUpdater.return_value
+        rc = main(["--start", "2023-01-01", "--end", "2023-02-01"])
+        self.assertEqual(rc, 0)
+        kwargs = inst.run_updates.call_args.kwargs
+        self.assertEqual(kwargs["networks"], "^.*$")
+        self.assertEqual(kwargs["stations"], "^.*$")
+        self.assertIsNone(kwargs["locations"])
+        self.assertIsNone(kwargs["channels"])
+
+    @patch("apps.cli.get_db_client")
+    @patch("apps.cli.AvailabilityUpdater")
+    def test_main_rejects_reversed_range(self, MockUpdater, _mock_db):
+        rc = main(["--start", "2009-01-01", "--end", "2008-01-01"])
+        self.assertEqual(rc, 2)
+        MockUpdater.return_value.run_updates.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -60,6 +60,52 @@ class TestAvailabilityUpdater(unittest.TestCase):
         }
         self.assertEqual(pipeline[2], expected_merge)
 
+    def test_daily_match_omits_nslc_filters_by_default(self):
+        """With locations/channels=None the $match has no loc/cha keys (scheduler path)."""
+        self.updater.update_availability_daily(
+            "^.*$", "^.*$", datetime(2023, 1, 1), datetime(2023, 1, 2)
+        )
+        match = self.mock_db.daily_streams.aggregate.call_args[0][0][0]["$match"]
+        self.assertNotIn("loc", match)
+        self.assertNotIn("cha", match)
+
+    def test_daily_match_applies_nslc_filters_when_given(self):
+        """Provided loc/cha become exact-match $in clauses; '' is a valid (empty) loc."""
+        self.updater.update_availability_daily(
+            "^.*$", "^.*$", datetime(2023, 1, 1), datetime(2023, 1, 2),
+            locations=["", "00"], channels=["HHZ"],
+        )
+        match = self.mock_db.daily_streams.aggregate.call_args[0][0][0]["$match"]
+        self.assertEqual(match["loc"], {"$in": ["", "00"]})
+        self.assertEqual(match["cha"], {"$in": ["HHZ"]})
+
+    def test_continuous_match_applies_nslc_filters_when_given(self):
+        self.updater.update_availability_continuous(
+            "^.*$", "^.*$", datetime(2023, 1, 1), datetime(2023, 1, 2),
+            locations=["00"], channels=["BHZ", "BHN"],
+        )
+        match = self.mock_db.daily_streams.aggregate.call_args[0][0][0]["$match"]
+        self.assertEqual(match["loc"], {"$in": ["00"]})
+        self.assertEqual(match["cha"], {"$in": ["BHZ", "BHN"]})
+
+    def test_run_updates_threads_nslc_to_both_pipelines(self):
+        self.updater.update_availability_daily = MagicMock()
+        self.updater.update_availability_continuous = MagicMock()
+        self.updater.run_updates(
+            networks="^(IV)$", stations="^(ABC)$",
+            start_date=datetime(2008, 1, 1), end_date=datetime(2009, 1, 1),
+            locations=[""], channels=["HHZ"],
+        )
+        for mock in (
+            self.updater.update_availability_daily,
+            self.updater.update_availability_continuous,
+        ):
+            args = mock.call_args[0]
+            self.assertEqual(args[0], "^(IV)$")
+            self.assertEqual(args[1], "^(ABC)$")
+            self.assertEqual(args[4], [""])      # locations
+            self.assertEqual(args[5], ["HHZ"])   # channels
+
     def test_update_availability_continuous_pipeline(self):
         """
         Test that update_availability_continuous calls aggregate with the correct pipeline.

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "ws-availability"
-version = "1.1.0b1"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

v1.1.1 over the released v1.1.0. Additive and install-compatible — no changes to the documented install flow.

- **`avail-rebuild` CLI** (`apps/cli.py`) — on-demand historical/scoped rebuild of the `availability` view for an arbitrary date range and optional NSLC, run inside the cacher (`docker exec fdsnws-availability-cacher avail-rebuild …`). The daily scheduler only refreshes a rolling recent window and can't repair historical gaps after a WFCatalog backfill; this fills that gap.
- **`apps/updater.py`** — backward-compatible refactor to accept optional `loc`/`cha` filters. With both `None` (the scheduler's path) the `$match` is byte-identical to v1.1.0, so the daily update behaviour is unchanged.
- **Deploy fix (`docker-compose.yml`)** — bind-mount `./config.py:/appli/config.py:ro` on `api` and `cacher`. The published GHCR images ship without `config.py` and it was never mounted, so the README's *Option B — pull pre-built images* path crash-looped with `ModuleNotFoundError: No module named 'config'`. Build-locally (Option A) is unaffected.
- **README** — install/upgrade made self-contained: new *Upgrading from v1.0.x* section (per-version `config.py` keys, required `SENTRY_ENVIRONMENT`, host-cron removal); the `BETA.md` dependency is dropped.

## Validation

- Install flow byte-identical to v1.1.0 (no changes to `Dockerfile.*`, `config.py.sample`, `gunicorn.conf.py`).
- Deployed and verified on the NOA production server (real WFCatalog): `/version` → `1.1.1`, `/extent` → 200 on live data with the config mount in place; rolled back cleanly.
- The CLI + updater changes have run on NOA production since 2026-06-11.
- `tests/test_cli.py`, `tests/test_updater.py` added.

## Release

Publish is tag-driven (`publish.yml`). After merge, tag `v1.1.1` on `master` to publish PyPI + GitHub Release + GHCR images.